### PR TITLE
Channel-10 pitched noise on a dedicated path; add accuracy & latency host tests

### DIFF
--- a/AdsrEnvelope.cpp
+++ b/AdsrEnvelope.cpp
@@ -293,9 +293,12 @@ void AdsrEnvelope::Reset(uint8_t attack, uint8_t decay, uint8_t sustain, uint8_t
     isNull = true;
   } else {
     isNull = false;
-    // TODO: optimize this case - decay not often used.
     if (decay && sustain < maxMidiVal) {
-      _decayDec = (1.0 - _sustain) * (1.0 / _decay) * controlClockTickMs;
+      // (1.0/_decay)*controlClockTickMs is exactly AdsrCurveLevelStep[decay] (=
+      // controlClockTickMs/AdsrCurveMs[decay]), so reuse that precomputed
+      // reciprocal -- like _attackInc/_releaseDec above -- instead of a runtime
+      // divide (and the double-literal arithmetic) on the no-FPU target.
+      _decayDec = (cr_fp_t(1) - _sustain) * AdsrCurveLevelStep[decay];
     }
   }
   level = 0;

--- a/CRMidi.cpp
+++ b/CRMidi.cpp
@@ -27,7 +27,6 @@ bool CRMidi::setCC(uint8_t *value, uint8_t newValue) {
 CRMidi::CRMidi(OscillatorController *oc, CRIO *crio) {
   _oc = oc;
   _crio = crio;
-  _noiseModPending = false;
   _oc->ResetAll();
   _controlCounter = 0;
   bzero(&_oscillatorChannelMap, sizeof(_oscillatorChannelMap));
@@ -41,6 +40,7 @@ CRMidi::CRMidi(OscillatorController *oc, CRIO *crio) {
   }
   _percussionChannel = _midiChannels + maxMidiChannel;
   _midiChannelMap[PERC_CHAN] = _percussionChannel;
+  _percussionChannel->noiseModulated = true;
   ResetAll();
   updateCoeff();
 }
@@ -74,10 +74,6 @@ void CRMidi::ResetAll() {
   FOR_ALL_CHAN(ResetChannel(midiChannel));
 }
 
-inline int16_t randomBend() {
-  return random(0, 16383) - 8192;
-}
-
 void CRMidi::updateCoeff() {
   _crio->updateCoeff();
   _crio->updateLcdCoeff();
@@ -95,17 +91,11 @@ bool CRMidi::HandleControl() {
       FOR_ALL_CHAN(ExpireNotes(midiChannel));
       break;
     case 2:
-      if (!_noiseModPending) {
-        _percussionChannel->SetBend(randomBend(), _oc);
-        _noiseModPending = true;
-      }
-      break;
-    case 3:
       if (!_crio->pollPots()) {
         complete = true;
       }
       break;
-    case 4:
+    case 3:
       updateCoeff();
       break;
     default:
@@ -355,7 +345,12 @@ cr_fp_t CRMidi::Modulate(Oscillator *audibleOscillator) {
     p = ModulateChain(p - _crio->breakoutUs, audibleOscillator, midiChannel) + _crio->breakoutUs;
   }
   if (_percussionChannel == midiChannel) {
-    _noiseModPending = false;
+    // Pitched noise: give the voice that just pulsed a fresh random period
+    // inside its precomputed window. One random pick + a period write -- no
+    // bend/retune, and no vibrato LFO (which other channels keep via FMModulate).
+    if (audibleOscillator->noiseSpan()) {
+      audibleOscillator->ApplyNoisePeriod(random(audibleOscillator->noiseSpan() + 1));
+    }
   } else {
     FMModulate(midiChannel);
   }

--- a/CRMidi.h
+++ b/CRMidi.h
@@ -50,7 +50,6 @@ class CRMidi {
     OscillatorController *_oc;
     CRIO *_crio;
     uint8_t _controlCounter;
-    bool _noiseModPending;
 };
 
 #endif

--- a/MidiChannel.cpp
+++ b/MidiChannel.cpp
@@ -14,6 +14,7 @@
 
 MidiChannel::MidiChannel() {
   bzero(&_noteMap, sizeof(_noteMap));
+  noiseModulated = false;
   Reset();
 }
 
@@ -111,10 +112,18 @@ void MidiChannel::NoteOn(uint8_t note, uint8_t velocity, MidiNote *midiNote, Osc
   if (detune2 != DEFAULT_DETUNE || detune2Abs != DEFAULT_DETUNE) {
     _AddOscillatorToNote(BendHz(midiNote, midiTuneCents[detune2]), midiNote, oc, int(detune2Abs) - int(DEFAULT_DETUNE));
   }
+  // Stamp the noise window on every voice -- a non-zero span only for the
+  // percussion channel, zero (cleared) otherwise. Doing it unconditionally also
+  // clears any stale window left on an oscillator recycled from the free pool.
+  cr_tick_t noisePMin = 0, noiseSpan = 0;
+  if (noiseModulated) {
+    _pitchBender.NoiseBounds(note, noisePMin, noiseSpan);
+  }
   for (OscillatorDeque::const_iterator o = midiNote->oscillators.begin(); o != midiNote->oscillators.end(); ++o) {
     Oscillator *oscillator = *o;
     oscillator->audible = true;
     oscillator->envelope = &(midiNote->envelope);
+    oscillator->SetNoiseRange(noisePMin, noiseSpan);
   }
   _midiNotes.push_back(midiNote);
   _noteMap[note] = midiNote;

--- a/MidiChannel.h
+++ b/MidiChannel.h
@@ -63,8 +63,8 @@ class PitchBender {
       // Interpolate toward the bend target in inverse-Hz space. This previously
       // used pitchToHz (forward Hz), but the bend value became inverse-Hz in the
       // avoid-division change, so forwardHz - invHz was dimensionally wrong and
-      // sent any bent note (and the ch10 random-bend noise effect) to garbage
-      // frequencies. Inverse-Hz interpolation is consistent and division-free.
+      // sent any bent note to garbage frequencies. Inverse-Hz interpolation is
+      // consistent and division-free.
       // (origin/main's "Fix pitchbend" made the same pitchToHz->pitchToHzInv
       // correction but kept cr_fp_t; this branch supersedes it with cr_hzinv_t's
       // 30-bit inverse-Hz precision.)
@@ -72,6 +72,24 @@ class PitchBender {
       hzInv += window;
     }
     return hzInv;
+  }
+  // Master-clock period window for pitched noise: [pMin, pMin+span] spans the
+  // bend range either side of the played note (clamped like BendHz), read
+  // straight from the integer pitchToPeriod[] table. Computed once per note on
+  // so the per-pulse noise update is just one random pick inside the window --
+  // no inverse-Hz math, no division. Higher pitch -> smaller period, so pMin is
+  // at note+range and the wider period (pMax) is at note-range.
+  void NoiseBounds(uint8_t pitch, cr_tick_t &pMin, cr_tick_t &span) const {
+    int lo = int(pitch) - int(_pitchBendRange);
+    if (lo < 0) {
+      lo = 0;
+    }
+    int hi = int(pitch) + int(_pitchBendRange);
+    if (hi > _maxPitch) {
+      hi = _maxPitch;
+    }
+    pMin = pitchToPeriod[hi];
+    span = pitchToPeriod[lo] - pMin;
   }
  private:
   int16_t _bend;
@@ -110,6 +128,10 @@ class MidiChannel {
     uint8_t coarseModulation;
     uint8_t volume;
     bool lfoRestart;
+    // Structural (set once for the percussion channel), not a resettable CC:
+    // when true, note on stamps each voice's oscillator with a noise period
+    // window so Modulate() drives it as pitched noise instead of vibrato.
+    bool noiseModulated;
    private:
     void _AddOscillatorToNote(cr_hzinv_t hz, MidiNote *midiNote, OscillatorController *oc, int periodOffset);
     MidiNoteDeque _midiNotes;

--- a/Oscillator.cpp
+++ b/Oscillator.cpp
@@ -12,12 +12,14 @@
 #include "types.h"
 
 
-Oscillator::Oscillator() : hzInv(0), envelope(0), index(0), _periodOffset(0), _hzPulseUsScale(0), _velocityScale(0) {
+Oscillator::Oscillator() : hzInv(0), envelope(0), index(0), _periodOffset(0), _hzPulseUsScale(0), _velocityScale(0), _noisePMin(0), _noiseSpan(0) {
   Reset();
 }
 
 void Oscillator::Reset() {
   audible = false;
+  _noisePMin = 0;
+  _noiseSpan = 0;
   SetFreq(1, 1, 0, 2, 0);
 }
 

--- a/Oscillator.h
+++ b/Oscillator.h
@@ -25,11 +25,29 @@ class Oscillator {
   cr_tick_t SetNextTick(cr_tick_t masterClock);
   void ScheduleNow(cr_tick_t masterClock);
   void Reset();
+  // Channel-10 pitched noise. SetNoiseRange stamps the period window [pMin,
+  // pMin+span] (precomputed from pitchToPeriod[] at note on); ApplyNoisePeriod
+  // drops a fresh random period inside it. The mutation is lazy (it only sets
+  // _clockPeriod, like SetFreqLazy) -- it takes effect at the oscillator's next
+  // SetNextTick with no reschedule, which is the cheapest possible update.
+  void SetNoiseRange(cr_tick_t pMin, cr_tick_t span) { _noisePMin = pMin; _noiseSpan = span; }
+  cr_tick_t noiseSpan() const { return _noiseSpan; }
+  void ApplyNoisePeriod(cr_tick_t offset) {
+    cr_tick_t period = _noisePMin + offset;
+    _clockPeriod = period ? period : 1;
+  }
   cr_hzinv_t hzInv;
   cr_fp_t pulseUsScale;
   bool audible;
   AdsrEnvelope *envelope;
   uint8_t index;
+#ifdef CR_HOST_TEST
+  // Read-only period introspection for host MIDI tests (test/host/test_midi.cpp).
+  // Its only caller is the test, which build.sh's repo-root cppcheck does not
+  // see, so suppress the resulting unused-function report.
+  // cppcheck-suppress unusedFunction
+  cr_tick_t TestClockPeriod() const { return _clockPeriod; }
+#endif
  private:
   void _updateNextClock(cr_tick_t offset);
   void _computeHzPulseUsScale(uint8_t newPitch);
@@ -40,6 +58,8 @@ class Oscillator {
   cr_tick_t _nextClock;
   cr_fp_t _maxHz;
   cr_fp_t _maxHzInv;
+  cr_tick_t _noisePMin;
+  cr_tick_t _noiseSpan;
 };
 
 #endif

--- a/test/host/stubs/Arduino.h
+++ b/test/host/stubs/Arduino.h
@@ -16,8 +16,8 @@ enum { LOW = 0, HIGH = 1, INPUT = 0, OUTPUT = 1, INPUT_PULLUP = 2 };
 // Pulse output timing is not exercised by host tests.
 inline void delayMicroseconds(unsigned int) {}
 
-// Deterministic stand-in: return the low bound so percussion's randomBend() is
-// repeatable across runs (real firmware uses the hardware RNG).
+// Deterministic stand-in: return the low bound so percussion's pitched-noise
+// period pick is repeatable across runs (real firmware uses the hardware RNG).
 inline long random(long howsmall, long howbig) {
   (void)howbig;
   return howsmall;

--- a/test/host/test_frequency.cpp
+++ b/test/host/test_frequency.cpp
@@ -227,6 +227,87 @@ void TestSweepResolutionTo2k() {
         worst_cents);
 }
 
+// Lock the synth's worst-case pitch error across its whole operating envelope,
+// so any change that detunes the instrument fails here. The envelope is: every
+// playable MIDI note (default detune/no bend -> the pitchToPeriod[] path) and
+// every arbitrary frequency a detune or pitch bend can request, up to the top
+// note times full +cents detune (the hzInv -> period multiply path). The only
+// irreducible error is single-master-clock period rounding -- largest at the
+// shortest period, i.e. the highest pitch. Today the quantizer hits exactly that
+// floor on both paths, so the cap is that floor (plus a tiny allowance for
+// cr_hzinv_t's 1/f truncation on the arbitrary path). A failure means accuracy
+// regressed past the hardware floor: hzInv precision was lost, or pitchToPeriod[]
+// desynced from masterClockHz.
+void TestWorstCaseAccuracyCap() {
+  std::printf("[cap] worst-case pitch error across the operating envelope\n");
+  Oscillator osc;
+  osc.SetMaxPitch(maxMidiPitch);
+
+  double worst = 0.0, worstHz = 0.0;
+  const char *worstWhat = "";
+  cr_tick_t minPeriod = ~static_cast<cr_tick_t>(0);
+
+  // (a) Every playable plain note: the precomputed pitchToPeriod[] path.
+  for (int note = 1; note <= maxMidiPitch; ++note) {
+    cr_tick_t period = PeriodForHzInv(&osc, pitchToHzInv[note], note);
+    if (period < minPeriod) {
+      minPeriod = period;
+    }
+    double err = std::fabs(ToCents(RealizedHz(period), static_cast<double>(pitchToHz[note])));
+    if (err > worst) {
+      worst = err;
+      worstHz = static_cast<double>(pitchToHz[note]);
+      worstWhat = "note";
+    }
+  }
+
+  // (b) Arbitrary (detuned / pitch-bent) frequencies, up to the top note times
+  // full +cents detune -- the highest frequency normal controls can request.
+  const double topHz = static_cast<double>(pitchToHz[maxMidiPitch]) *
+                       static_cast<double>(midiTuneCents[maxMidiVal]);
+  double worstExcess = 0.0;
+  for (double f = 20.0; f <= topHz + 1e-9; f += 0.1) {
+    cr_tick_t period = PeriodForHzInv(&osc, cr_hzinv_t(1.0 / f));
+    if (period < minPeriod) {
+      minPeriod = period;
+    }
+    double err = std::fabs(ToCents(RealizedHz(period), f));
+    if (err > worst) {
+      worst = err;
+      worstHz = f;
+      worstWhat = "freq";
+    }
+    double excess = err - PeriodRoundingBoundCents(period);
+    if (excess > worstExcess) {
+      worstExcess = excess;
+    }
+  }
+
+  const double floorCap = PeriodRoundingBoundCents(minPeriod);
+  // cr_hzinv_t truncation on the arbitrary path is documented < 0.01 cents; allow
+  // a generous 1 cent so the cap tracks the physical floor, not a magic number.
+  const double kHzInvTruncationCents = 1.0;
+  const double cap = floorCap + kHzInvTruncationCents;
+  std::printf("  operating range: up to %.1f Hz (note %u + full cents detune)\n",
+              topHz, maxMidiPitch);
+  std::printf("  worst-case error: %.2f cents (at %.1f Hz, %s path)\n",
+              worst, worstHz, worstWhat);
+  std::printf("  single-clock floor at top (period %lu ticks): %.2f cents; "
+              "worst excess over floor: %.4f cents\n",
+              (unsigned long)minPeriod, floorCap, worstExcess);
+  std::printf("  --> cap = %.2f cents (floor %.2f + %.2f truncation allowance)\n",
+              cap, floorCap, kHzInvTruncationCents);
+
+  CHECK(worst <= cap,
+        "worst-case pitch error %.2f cents exceeds cap %.2f -- accuracy regressed "
+        "past the single-master-clock floor",
+        worst, cap);
+  // Guard the test is actually exercising the lossy quantizer (not measuring nothing).
+  CHECK(worst > 5.0,
+        "worst-case error %.2f cents implausibly small -- test not exercising the range",
+        worst);
+}
+
 // Pitch bend now interpolates in inverse-Hz space (PitchBender::BendHz). This
 // mirrors that math against the real tables + oscillator and asserts a bent note
 // is sane: endpoints land on the note and its bend target (to the single-clock
@@ -296,6 +377,7 @@ int main() {
   TestPeriodTableExact();
   TestNoteAccuracyTo2k();
   TestSweepResolutionTo2k();
+  TestWorstCaseAccuracyCap();
   TestBendInverseHz();
   TestTimingGranularity();
   std::printf("\n%s (%d failure%s)\n", g_failures == 0 ? "PASS" : "FAIL",

--- a/test/host/test_midi.cpp
+++ b/test/host/test_midi.cpp
@@ -133,6 +133,18 @@ class IsrDriver {
   // Total master-clock advances so far == elapsed time * masterClockHz.
   unsigned long masterTicks() const { return masterTicks_; }
 
+  // Worst-case latency instrumentation. MIDI.read() (the only point an incoming
+  // message is parsed) runs exactly when HandleControl() completes a cycle, so
+  // the spacing between those completions bounds how long a just-missed message
+  // waits to be processed. Call ResetLatency() to start a clean measurement
+  // window, then read maxReadGap() (in master ISRs).
+  void ResetLatency() {
+    maxReadGap_ = 0;
+    readCount_ = 0;
+  }
+  unsigned long maxReadGap() const { return maxReadGap_; }
+  unsigned long readCount() const { return readCount_; }
+
  private:
   // Every oc.Triggered() is one master-clock tick; count them so the test has an
   // exact, monotonic time base for measuring the pin's pulse rate.
@@ -168,6 +180,16 @@ class IsrDriver {
     if (oc_.controlTriggered) {
       if (crmidi_.HandleControl()) {
         oc_.controlTriggered = false;
+        // chime_red2.ino calls MIDI.read() here -- the sole point a MIDI byte is
+        // parsed. Record the ISR spacing between these completions.
+        if (readCount_ > 0) {
+          const unsigned long gap = masterTicks_ - lastReadTick_;
+          if (gap > maxReadGap_) {
+            maxReadGap_ = gap;
+          }
+        }
+        lastReadTick_ = masterTicks_;
+        ++readCount_;
       }
     }
   }
@@ -177,6 +199,9 @@ class IsrDriver {
   CRIO &crio_;
   void (IsrDriver::*state_)();
   unsigned long masterTicks_ = 0;
+  unsigned long lastReadTick_ = 0;
+  unsigned long maxReadGap_ = 0;
+  unsigned long readCount_ = 0;
 };
 
 // note on allocates one audible oscillator at the note's frequency; note off
@@ -341,15 +366,34 @@ void TestPercussionChannel() {
         AudibleCount(oc));
 
   crio.percEnabled = true;
-  crmidi.handleNoteOn(10, 60, 100);
+  const uint8_t note = 60;
+  crmidi.handleNoteOn(10, note, 100);
   CHECK(AudibleCount(oc) >= 1, "percussion enabled: note should sound, got %d",
         AudibleCount(oc));
 
-  // Modulating a percussion voice takes the percussion branch (clears the noise
-  // mod flag) rather than applying vibrato; it still yields a sane pulse.
+  // Channel 10 has its own pitched-noise path (no shared vibrato LFO, no bend
+  // retune): note on stamps the voice with a master-clock period window one bend
+  // range either side of the note, so the voice starts at the note's own period.
   Oscillator *p = FirstAudible(oc);
+  CHECK(p != NULL && p->TestClockPeriod() == pitchToPeriod[note],
+        "percussion: voice should start at note period %u, got %u",
+        pitchToPeriod[note], p ? p->TestClockPeriod() : 0);
+
+  // Modulate() still yields a sane pulse, and moves the voice to a random period
+  // inside the window [period(note+range), period(note-range)]. The host's
+  // deterministic random() returns the low bound, so the period lands exactly on
+  // the window minimum -- the highest pitch, period(note+range).
+  const uint8_t hi = note + midiPitchBendRange;  // +12 semitones
+  const uint8_t lo = note - midiPitchBendRange;   // -12 semitones
   CHECK(p != NULL && crmidi.Modulate(p) > cr_fp_t(0),
         "percussion: Modulate should return a positive pulse");
+  CHECK(p != NULL && p->TestClockPeriod() == pitchToPeriod[hi],
+        "percussion noise: period %u != window min %u (note + %u semis)",
+        p ? p->TestClockPeriod() : 0, pitchToPeriod[hi], midiPitchBendRange);
+  CHECK(p != NULL && p->TestClockPeriod() >= pitchToPeriod[hi] &&
+            p->TestClockPeriod() <= pitchToPeriod[lo],
+        "percussion noise: period %u outside window [%u, %u]",
+        p ? p->TestClockPeriod() : 0, pitchToPeriod[hi], pitchToPeriod[lo]);
 }
 
 // Exercise the remaining control-change handlers, the program-change handler,
@@ -615,6 +659,100 @@ void TestEndToEndPinOscillation() {
   }
 }
 
+// Worst-case latency from a MIDI message arriving to the synth acting on it,
+// measured in master-clock ISRs. Two stages:
+//
+//  (1) Parse latency. The .ino only calls MIDI.read() when the control task
+//      (CRMidi::HandleControl) completes a cycle, and the control task only
+//      advances on ISRs where no oscillator is due and no pulse is being output.
+//      So sounding voices steal ISRs from it and spread the MIDI.read() points
+//      apart. A message arriving just after a read waits until the next one --
+//      that worst-case spacing is measured here, idle and under polyphony.
+//
+//  (2) Act latency. Once handleNoteOn runs, the voice is scheduled (ScheduleNow)
+//      and the coil pin first pulses a few ISRs later. Measured on a fresh voice
+//      (the shared coil pin can't attribute a pulse to one voice under load).
+//
+// Reported (not a tight pass/fail, except sanity ceilings): worst total =
+// parse + act. This characterises responsiveness and guards against a change
+// that lets the control task be starved of MIDI service.
+void TestMessageLatency() {
+  std::printf("[latency] worst-case MIDI message processing latency\n");
+  const double usPerTick = 1e6 / static_cast<double>(masterClockHz);
+
+  // Max ISRs between MIDI.read() points, for `voices` sustained notes starting at
+  // `note`, measured over `ticks` ISRs after the schedule settles.
+  auto readGap = [](uint8_t voices, uint8_t note, unsigned long ticks) -> unsigned long {
+    OscillatorController oc;
+    TestCRIO crio;
+    CRMidi crmidi(&oc, &crio);
+    IsrDriver driver(oc, crmidi, crio);
+    for (uint8_t v = 0; v < voices; ++v) {
+      crmidi.handleNoteOn(1, note + v, 100);  // distinct notes -> distinct voices
+    }
+    for (int i = 0; i < 4000; ++i) {
+      driver.Tick();  // let scheduling reach steady state
+    }
+    driver.ResetLatency();
+    for (unsigned long i = 0; i < ticks; ++i) {
+      driver.Tick();
+    }
+    return driver.maxReadGap();
+  };
+
+  const unsigned long kRun = 200000;  // ~3.8 s of synth time
+  const unsigned long idleGap = readGap(0, 0, kRun);
+  const unsigned long chordGap = readGap(16, 60, kRun);              // dense mid chord
+  const unsigned long topGap = readGap(16, maxMidiPitch - 15, kRun);  // 16 high voices
+
+  // Act latency: handleNoteOn -> first coil pulse, on a fresh voice.
+  unsigned long actTicks = 0;
+  {
+    OscillatorController oc;
+    TestCRIO crio;
+    CRMidi crmidi(&oc, &crio);
+    IsrDriver driver(oc, crmidi, crio);
+    for (int i = 0; i < 200; ++i) {
+      driver.Tick();
+    }
+    crHostPin(coilOutPin).Reset();
+    const unsigned long t0 = driver.masterTicks();
+    crmidi.handleNoteOn(1, 60, 100);
+    const unsigned long cap = t0 + 100000;
+    while (crHostPin(coilOutPin).risingEdges == 0 && driver.masterTicks() < cap) {
+      driver.Tick();
+    }
+    CHECK(crHostPin(coilOutPin).risingEdges > 0, "act latency: fresh voice never pulsed");
+    if (crHostPin(coilOutPin).risingEdges > 0) {
+      actTicks = crHostPin(coilOutPin).firstRisingTick - t0;
+    }
+    crHostPin(coilOutPin).Reset();
+  }
+
+  const unsigned long worst = chordGap + actTicks;
+  std::printf("  parse latency, ISRs between MIDI.read(): idle %lu, 16-voice chord %lu, "
+              "16 high voices %lu\n", idleGap, chordGap, topGap);
+  std::printf("  act latency, note-on -> first coil pulse: %lu ISRs\n", actTicks);
+  std::printf("  --> worst-case message latency (16-voice chord): %lu ISRs = %.1f us = %.3f ms\n",
+              worst, worst * usPerTick, worst * usPerTick / 1000.0);
+  std::printf("  --> adversarial 16x high-note load, parse latency: %lu ISRs = %.1f us\n",
+              topGap, topGap * usPerTick);
+
+  // Sanity ceilings: generous, meant to catch a control task that stops servicing
+  // MIDI, not normal cadence. Idle tracks the control-cycle period; loaded stays
+  // bounded (no starvation).
+  // Measured today (deterministic, bit-identical across platforms): idle 11,
+  // chord 23, high 29, act 2 ISRs. Ceilings sit a few x above to lock against a
+  // real starvation regression while tolerating minor control-cadence tweaks.
+  CHECK(idleGap > 0 && idleGap <= 32,
+        "idle MIDI.read spacing %lu ISRs unexpected (control cadence broken?)", idleGap);
+  CHECK(chordGap <= 128,
+        "16-voice MIDI.read spacing %lu ISRs too high -- control task starved", chordGap);
+  CHECK(topGap <= 256,
+        "adversarial MIDI.read spacing %lu ISRs too high -- control task starved", topGap);
+  CHECK(actTicks > 0 && actTicks <= 32, "act latency %lu ISRs unexpected", actTicks);
+}
+
 }  // namespace
 
 int main() {
@@ -634,6 +772,7 @@ int main() {
   TestModulation();
   TestControlChangeHandling();
   TestEndToEndPinOscillation();
+  TestMessageLatency();
   std::printf("\n%s (%d failure%s)\n", g_failures == 0 ? "PASS" : "FAIL",
               g_failures, g_failures == 1 ? "" : "s");
   return g_failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Channel-10 pitched noise: dedicated per-oscillator path

Ch10 noise used to borrow the per-channel **pitch-bend** path — which is also the **vibrato** slot. It pushed a full-range `randomBend()` through `SetBend → PitchBender → RetuneNotes` every control cycle, running a 64-bit `hzInvToTicks()` multiply per voice, and took the percussion branch in `Modulate()` so a ch10 voice could never reach the vibrato LFO.

Now each voice carries a precomputed master-clock **period window** (`pitchToPeriod[note ± bend range]`, division-free) stamped at note-on, and `Modulate()` drops one random period into it per pulse for the voice that just fired:

- **per update:** `random()` + add + a lazy `_clockPeriod` write — no bend, no retune, no inverse-Hz math (was: 64-bit multiply + table lookup + interpolation + channel-wide retune).
- deletes `randomBend()`, `_noiseModPending`, and the `HandleControl` noise case.
- **side benefit:** ch10 no longer clobbers `PitchBender`, so real pitch bend works there too.
- audible window unchanged (±bend range, default ±12 semitones — matches `MIDI.md`); noise now refreshes per-pulse per-voice (richer, still free).
- memory: +128 B SRAM (two `cr_tick_t` × 16 oscillators) + 9 B (one `bool`/channel); negligible on the Due.

## AdsrEnvelope: remove a runtime divide

`Reset()` computed `_decayDec = (1.0 - _sustain) * (1.0 / _decay) * controlClockTickMs` on every note-on with decay — a runtime division + double-literal math on a no-FPU target. `(1.0/_decay)*controlClockTickMs` is exactly `AdsrCurveLevelStep[decay]` (the reciprocal already used for `_attackInc`/`_releaseDec`), so it collapses to `(cr_fp_t(1) - _sustain) * AdsrCurveLevelStep[decay]` — no divide, no double, retires the standing TODO. Numerically equivalent (envelope test sustain unchanged at 0.504).

## New host tests

**`test_frequency.cpp` → `TestWorstCaseAccuracyCap`** — locks worst-case pitch error across the whole operating envelope (every playable note via `pitchToPeriod[]`, plus arbitrary/detuned frequencies up to the top note + full cents detune via the `hzInv` path).
- Measured today: **35.62 cents @ 2148 Hz**, exactly the single-master-clock rounding floor (35.70 cents at period 24); hzInv truncation excess only 0.69 cents.
- Cap is principled (floor at the shortest period + 1-cent truncation allowance = 36.70), not a magic number — fails if hzInv precision is lost or `pitchToPeriod[]` desyncs from `masterClockHz`.

**`test_midi.cpp` → `TestMessageLatency`** — reports worst-case MIDI message processing latency in ISRs. Instruments `IsrDriver` to track the spacing between `MIDI.read()` points (gated on `HandleControl()` completing — the real parse gate), plus the schedule→first-pulse "act" latency.
- parse: 11 ISRs idle / 23 (16-voice chord) / 29 (16 high voices); act: 2 ISRs.
- **worst-case ≈ 25 ISRs = 475 µs** (16-voice chord); the control task never starves even adversarially.
- Deterministic ceilings (bit-identical fixed-point math) guard against starvation regressions.

`TestPercussionChannel` extended to assert the new per-voice noise window deterministically.

## Verification
Docker host-test image builds (so both suites compile **and** the `cppcheck --enable=all` gate passes) and `docker run` exits 0 with both suites reporting `PASS (0 failures)`. Arduino board builds (`build.sh`) not run here; changes are platform-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)