### PR TITLE
Free a sustain-0 note when its decay completes

### DIFF
--- a/AdsrEnvelope.cpp
+++ b/AdsrEnvelope.cpp
@@ -336,6 +336,15 @@ void AdsrEnvelope::Decay() {
 }
 
 void AdsrEnvelope::Sustain() {
+  // Sustain 0 means "die after decay": idle now instead of holding at level 0, so
+  // the voice is freed and stops firing the coil's breakout-time minimum pulse.
+  // Otherwise a long-held note whose amplitude has already decayed to zero (e.g. a
+  // struck FM bell -- long decay, zero sustain) keeps emitting a faint breakout-
+  // floor tone until note-off. A non-zero sustain holds as before.
+  if (_sustain <= cr_fp_t(0)) {
+    Idle();
+    return;
+  }
   level = _sustain;
   ChangePhase(ENV_SUSTAIN);
 }

--- a/test/host/test_midi.cpp
+++ b/test/host/test_midi.cpp
@@ -1028,6 +1028,42 @@ void TestClockSyncLfo() {
         "CC14=0 should restore free-running");
 }
 
+// A note with sustain 0 frees itself when its decay completes, WITHOUT waiting
+// for a note-off -- so a long-held struck sound (e.g. an FM bell) stops cleanly
+// instead of holding the coil's breakout-time minimum pulse as a faint tone. A
+// note with non-zero sustain still holds until note-off.
+void TestSustainZeroFreesAfterDecay() {
+  std::printf("[env] sustain-0 note frees after decay; sustain>0 holds until "
+              "note off\n");
+  OscillatorController oc;
+  TestCRIO crio;
+  CRMidi crmidi(&oc, &crio);
+
+  // attack 0, short decay, sustain 0 -> rings the decay then dies on its own.
+  crmidi.handleControlChange(1, 73, 0); // attack 0
+  crmidi.handleControlChange(1, 75, 1); // short decay
+  crmidi.handleControlChange(1, 24, 0); // sustain 0
+  crmidi.handleNoteOn(1, 60, 100);
+  CHECK(AudibleCount(oc) == 1, "sustain-0 note should sound, got %d",
+        AudibleCount(oc));
+  RunControl(crmidi, 200); // well past the decay, no note-off sent
+  CHECK(AudibleCount(oc) == 0,
+        "sustain-0 note should free after decay without a note-off, got %d",
+        AudibleCount(oc));
+
+  // Non-zero sustain: a held note must keep sounding until note-off.
+  crmidi.handleControlChange(1, 24, 64); // sustain 64
+  crmidi.handleNoteOn(1, 64, 100);
+  RunControl(crmidi, 200); // no note-off
+  CHECK(AudibleCount(oc) == 1,
+        "sustain>0 held note should keep sounding without a note-off, got %d",
+        AudibleCount(oc));
+  crmidi.handleNoteOff(1, 64);
+  RunControl(crmidi, 40);
+  CHECK(AudibleCount(oc) == 0,
+        "sustain>0 note should free after note-off, got %d", AudibleCount(oc));
+}
+
 } // namespace
 
 int main() {
@@ -1044,6 +1080,7 @@ int main() {
   TestAllNotesOff();
   TestPercussionChannel();
   TestEnvelopeAdsr();
+  TestSustainZeroFreesAfterDecay();
   TestSchedulerAndLfoTick();
   TestModulation();
   TestControlChangeHandling();


### PR DESCRIPTION
## Summary
Fixes a faint **held tone "beyond the envelope"** on long-held struck sounds (noticed on the FM bells). A note with **sustain 0** decays to silence but, if held, never reached `ENV_IDLE` — it parked in the sustain phase at level 0 until note-off. Because `CRMidi::Modulate` adds the coil's breakout-time minimum back *after* the envelope scaling:

```
p = ModulateChain(pw - breakoutUs, ...) /* *= envelope level (→0) */ + breakoutUs;
```

a level-0 held note keeps firing a `breakoutUs`-wide pulse every cycle — an audible faint tone until note-off frees the voice.

`AdsrEnvelope::Sustain()` now **idles immediately when the sustain level is 0**, so the voice is freed (and stops pulsing) the moment its decay finishes — matching "sustain 0 = die after decay", and reclaiming the oscillator sooner. A non-zero sustain holds until note-off exactly as before. Only patches with **sustain CC 0** are affected (default notes are sustain 127 / null envelope, untouched).

## Evidence (FM bell C5 fixture, RMS over time)
| | 0–3.5 s | 3.5–8 s | 8 s+ |
| --- | --- | --- | --- |
| **before** | decay 5500→2375 | **plateau ~2375 (held floor tone)** | silence |
| **after** | decay 5500→2553 | **silence** | silence |

The bell now rings its decay and goes cleanly silent.

## Testing
- New `TestSustainZeroFreesAfterDecay`: a sustain-0 note frees after its decay **without** a note-off; a sustain>0 held note keeps sounding until note-off (regression guard for the held-note semantics).
- Full Docker gate green: cppcheck, soft-float, lint, and all suites pass (0 failures). The existing ADSR test (sustain 64) is unaffected.

## Notes
- Independent of the frequency-accuracy work (PR #38) — this is amplitude/envelope only, pre-existing on `main`. The two are orthogonal and both branch from current `main`.
- This is the recommended option from a design choice: a held sustain-0 voice could instead keep idling at the coil's minimum breakout (left as-is) — but freeing it is cleaner and reclaims the voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)