### PR TITLE
Render the coil breakout threshold (pulse width above breakoutUs)

### DIFF
--- a/test/host/IsrDriver.h
+++ b/test/host/IsrDriver.h
@@ -49,6 +49,12 @@ public:
   unsigned long maxReadGap() const { return maxReadGap_; }
   unsigned long readCount() const { return readCount_; }
 
+  // Width (microseconds) of the pulse scheduled by the most recent modulateISR.
+  // The SMF->WAV simulator (cr_render.cpp) uses it to model the coil's
+  // breakout: only the part of a pulse ABOVE breakoutUs makes sound, so it
+  // renders the audible width (pulse - breakoutUs), not the raw gate width.
+  double lastPulseUs() const { return lastPulseUs_; }
+
 private:
   // Every oc.Triggered() is one master-clock tick; count them so callers have
   // an exact, monotonic time base for measuring the pin's pulse rate.
@@ -65,6 +71,7 @@ private:
 
   void modulateISR() {
     cr_fp_t p = crmidi_.Modulate(oc_.audibleOscillator);
+    lastPulseUs_ = static_cast<double>(p);
     crio_.schedulePulse(p);
     Triggered();
     state_ = &IsrDriver::nextISR;
@@ -106,6 +113,7 @@ private:
   unsigned long lastReadTick_ = 0;
   unsigned long maxReadGap_ = 0;
   unsigned long readCount_ = 0;
+  double lastPulseUs_ = 0.0;
 };
 
 #endif // CR_HOST_ISR_DRIVER_H

--- a/test/host/cr_render.cpp
+++ b/test/host/cr_render.cpp
@@ -222,23 +222,45 @@ int main(int argc, char **argv) {
   std::vector<float> sig;
   sig.reserve(static_cast<size_t>(totalTicks));
 
+  // Coil breakout model. The coil only breaks out (makes sound) for the part of
+  // a pulse ABOVE breakoutUs -- a pulse <= breakoutUs can't break out, so it is
+  // silent; audible level scales with (pulseWidth - breakoutUs). The firmware's
+  // pulse is breakoutUs + (envelope/velocity-scaled width), so as a note decays
+  // its pulse shrinks toward breakoutUs. Rendering the RAW gate width made that
+  // tail a held floor tone; rendering only the AUDIBLE width lets it fade to
+  // silence, matching the coil. Each pulse emits `fullHigh` whole high samples
+  // plus one fractional sample for the partial tick.
+  const double tickUs = 1e6 / static_cast<double>(masterClockHz);
+  const double breakoutUs = static_cast<double>(crio.breakoutUs);
+
   unsigned long long evIdx = 0;
   unsigned long prevRising = coil.risingEdges;
   unsigned long long pulses = 0;
+  double fullHigh = 0.0; // remaining whole audible ticks for the current pulse
+  float fracHigh = 0.0f; // one trailing partial-tick sample, then 0
   for (unsigned long long t = 0; t < totalTicks; ++t) {
     while (evIdx < timed.size() && timed[evIdx].tick <= t) {
       Dispatch(crmidi, timed[evIdx].ev);
       ++evIdx;
     }
     driver.Tick();
-    // High if the gate is up at end of tick, or a pulse rose+fell within it.
-    const bool edge = coil.risingEdges != prevRising;
-    const bool high = coil.level || edge;
-    if (edge) {
+    if (coil.risingEdges != prevRising) {
       prevRising = coil.risingEdges;
       ++pulses;
+      const double audibleUs = driver.lastPulseUs() - breakoutUs;
+      const double audibleTicks = audibleUs > 0.0 ? audibleUs / tickUs : 0.0;
+      fullHigh = std::floor(audibleTicks);
+      fracHigh = static_cast<float>(audibleTicks - fullHigh);
     }
-    sig.push_back(high ? 1.0f : 0.0f);
+    float s = 0.0f;
+    if (fullHigh > 0.0) {
+      s = 1.0f;
+      fullHigh -= 1.0;
+    } else if (fracHigh > 0.0f) {
+      s = fracHigh;
+      fracHigh = 0.0f;
+    }
+    sig.push_back(s);
   }
   // Flush any events past the render window (e.g. a long tail truncated away).
   while (evIdx < timed.size()) {


### PR DESCRIPTION
## Summary
The SMF→WAV simulator (`cr-render`) turned the **raw coil gate width** into sound. But on the real coil, a pulse only **breaks out** (makes sound) for the part **above `breakoutUs`** — a pulse ≤ `breakoutUs` is silent, and audible level scales with `(pulseWidth − breakoutUs)`. The firmware's pulse is `breakoutUs + (envelope/velocity-scaled width)`, so as a note decays its pulse shrinks toward `breakoutUs`; rendering the raw gate made that low-level tail a **held floor tone** (most obvious on a struck FM bell ringing out) instead of fading to silence.

## Fix (renderer / host-harness only — no synth or device change)
- `IsrDriver` exposes the width of each scheduled pulse (`lastPulseUs`).
- The render loop emits a gate of the **audible width** `(pulse − breakoutUs)` per pulse — whole high samples plus one fractional sample for the partial tick — so a pulse at/below `breakoutUs` renders silent and a decaying note fades to silence.

## Effect (FM bell C5 decay tail, RMS as % of peak)
| time | before (raw gate) | after (breakout) |
| --- | --- | --- |
| 2.75 s | 13% | 13% |
| 3.00 s | **13%** | 12% |
| 3.25 s | **13%** | 11% |
| 3.50 s | **12%** | 10% |

Before: a flat ~13% **plateau** (the static held tone). After: a **steady decline** that fades to silence — the held floor is gone.

## Testing
- Full Docker gate green: cppcheck, soft-float, lint, all suites (0 failures). The render pitch tests are unchanged (every note still renders at +0.0 cents), confirming pitch/timing are untouched — only the per-pulse amplitude now models breakout.

## Notes
- Complements the sustain-0 voice-free fix (#39): that frees the voice after decay; this makes the decay tail itself fade correctly.
- Remaining bell character (it becomes a pure tone ~2.5 s in as the FM mod-index envelope decays brightness, with a fairly linear amplitude decay) is the preset's envelope shape, not the renderer — separate from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)